### PR TITLE
Add Google Analytics + GTM tags

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import tailwind from "@astrojs/tailwind";
 import { Graphviz } from "@hpcc-js/wasm";
 import rehypeGraphviz from "rehype-graphviz";
+import { VitePluginRadar } from 'vite-plugin-radar';
 
 
 let sidebar = JSON.parse(fs.readFileSync("generated/sidebar.json"));
@@ -22,7 +23,7 @@ export default defineConfig({
   integrations: [starlight({
     title: 'AEP',
     customCss: [
-      './src/tailwind.css',   
+      './src/tailwind.css',
     ],
     social: {
       github: config.urls.repo,
@@ -32,5 +33,17 @@ export default defineConfig({
   }),
   tailwind({
     applyBaseStyles: false,
-  })]
+  })],
+  vite: {
+    plugins: [
+      VitePluginRadar({
+        analytics: {
+          id: config.site.ga_tag
+        },
+        gtm: {
+          id: config.site.ga_tag
+        },
+      }),
+    ],
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "marked": "^14.1.2",
         "rehype-graphviz": "^0.3.0",
         "sharp": "^0.32.5",
-        "tailwindcss": "^3.4.10"
+        "tailwindcss": "^3.4.10",
+        "vite-plugin-radar": "^0.9.6"
       },
       "devDependencies": {
         "glob": "^11.0.0",
@@ -8532,6 +8533,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-radar": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-radar/-/vite-plugin-radar-0.9.6.tgz",
+      "integrity": "sha512-tLvUt7+iZznxYa8GmCrZBV3Q0fLQApsyg9EIJgaen8DjGky3vFIq9KoDWAoVMs9FZ5qbsSBb3YfSvoqwVV+5xw==",
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/vitefu": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "marked": "^14.1.2",
     "rehype-graphviz": "^0.3.0",
     "sharp": "^0.32.5",
-    "tailwindcss": "^3.4.10"
+    "tailwindcss": "^3.4.10",
+    "vite-plugin-radar": "^0.9.6"
   },
   "devDependencies": {
     "glob": "^11.0.0",


### PR DESCRIPTION
This adds in a Google Analytics + GTM tag using the config values from the aep.dev repo.