### PR TITLE
add sync key for global toggle

### DIFF
--- a/scripts/src/markdown.ts
+++ b/scripts/src/markdown.ts
@@ -73,7 +73,7 @@ ${this.contents}
         }
         for (var tab of tabs) {
             var new_tab = `
-<Tabs>
+<Tabs syncKey="exampleType">
   <TabItem label="Protocol Buffers">
 ${tab['proto']}
   </TabItem>


### PR DESCRIPTION
Fixes #46 

This makes all of the pages share the same OAS/Proto value, so users don't have to keep changing over to OAS. It doesn't add a global button in the header (that's harder).