### PR TITLE
OAS Samples showing too much

### DIFF
--- a/src/components/utils/sample.ts
+++ b/src/components/utils/sample.ts
@@ -19,7 +19,7 @@ function sampleYaml(code: string, path: string): string {
 
     let traversal = yaml_code;
 
-    for (let i = 0; i < segments.length - 1; i++) {
+    for (let i = 0; i < segments.length; i++) {
         if (segments[i] != "$") {
             current[segments[i]] = {};
             current = current[segments[i]];


### PR DESCRIPTION
Fixes #50 

This is an example of one of the samples in aep.dev/133 after this fix.

<img width="743" alt="Screenshot 2024-11-07 at 5 04 33 PM" src="https://github.com/user-attachments/assets/1e173563-bb2c-44e9-b346-3c0b34d5a064">
