### PR TITLE
feat(json-types): serialize types to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ generated/*.json
 src/content/docs/*.mdx
 src/content/docs/*.md
 src/content
-public/json-schema/*.json
+public/json-schema/**/*.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ Before following any other part of the guide, install the following:
 
 ```
 # clone the aeps and api-linter repositories, and point to their location
-export AEP_LOCATION=${AEP_LOCATION}
-export AEP_LINTER_LOC=${AEP_LINTER_LOC}
+export AEP_LINTER_LOC=${AEP_LINTER_LOC:-"../api-linter"}
+export AEP_LOCATION=${AEP_LOCATION:-"../aeps"}
+export AEP_COMPONENTS_LOC=${AEP_COMPONENTS_LOC:-"../aep-components"}
 # generate the pages required for the astro build
 npm run generate
 # build and run the astro site

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # a development script to generate and serve the site.
 
-export API_LINTER_LOC=${API_LINTER_LOC:-"../api-linter"}
+export AEP_LINTER_LOC=${AEP_LINTER_LOC:-"../api-linter"}
 export AEP_LOCATION=${AEP_LOCATION:-"../aeps"}
+export AEP_COMPONENTS_LOC=${AEP_COMPONENTS_LOC:-"../aep-components"}
+npm run generate
 npm run astro dev


### PR DESCRIPTION
The aep-components repository writes their types as yaml, and need to be written to json to be valid jsonschema files.