### PR TITLE
Add topics to the sidebar!

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,7 +33,7 @@ export default defineConfig({
     ],
     plugins: [
       starlightBlog(),
-      starlightSidebarTopics(sidebar),
+      starlightSidebarTopics(sidebar, {'exclude': ['/blog', '/blog/**/*']}),
     ],
     social: [
       {icon: 'github', label: 'GitHub', href: config.urls.repo},

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,9 @@ import starlight from '@astrojs/starlight';
 import * as fs from 'fs';
 import rehypeMermaid from "rehype-mermaid";
 import starlightBlog from 'starlight-blog';
+import starlightSidebarTopics from 'starlight-sidebar-topics';
+
+import tailwindcss from '@tailwindcss/vite';
 
 import tailwindcss from '@tailwindcss/vite';
 
@@ -28,13 +31,15 @@ export default defineConfig({
       // Path to your Tailwind base styles:
       './src/styles/global.css',
     ],
-    plugins: [starlightBlog()],
+    plugins: [
+      starlightBlog(),
+      starlightSidebarTopics(sidebar),
+    ],
     social: [
       {icon: 'github', label: 'GitHub', href: config.urls.repo},
       {icon: 'blueSky', label: 'BlueSky', href: 'https://bsky.app/profile/aep.dev'},
       {icon: 'youtube', label: 'YouTube', href: 'https://youtube.com/@aepdev/videos'}
     ],
-    sidebar: sidebar,
     components: {
       'Head': './src/components/overrides/Head.astro',
       'SkipLink': './src/components/overrides/SkipLink.astro',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "rehype-mermaid": "^3.0.0",
         "sharp": "^0.32.5",
         "starlight-blog": "^0.20.0",
+        "starlight-sidebar-topics": "^0.6.0",
         "tailwindcss": "^4.1.4",
         "vite-plugin-radar": "^0.9.6"
       },
@@ -8699,6 +8700,33 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/starlight-sidebar-topics": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/starlight-sidebar-topics/-/starlight-sidebar-topics-0.6.0.tgz",
+      "integrity": "sha512-ysmOR7zaHYKtk18/mpW4MbEMDioR/ZBsisu9bdQrq0v9BlHWpW7gAdWlqFWO9zdv1P7l0Mo1WKd0wJ0UtqOVEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.32.0"
+      }
+    },
+    "node_modules/starlight-sidebar-topics/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/static-eval": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "rehype-mermaid": "^3.0.0",
     "sharp": "^0.32.5",
     "starlight-blog": "^0.20.0",
+    "starlight-sidebar-topics": "^0.6.0",
     "tailwindcss": "^4.1.4",
     "vite-plugin-radar": "^0.9.6"
   },

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -63,7 +63,7 @@ async function writePage(dirPath: string, filename: string, outputPath: string, 
   writeFile(outputPath, contents.removeTitle().build())
 }
 
-async function writePages(dirPath: string, sidebar: Sidebar): Promise<Sidebar> {
+async function writePages(dirPath: string, sidebar: Sidebar[]): Promise<Sidebar[]> {
   const entries = await fs.promises.readdir(path.join(dirPath, "pages/general/"), { withFileTypes: true });
 
   let files = entries
@@ -305,7 +305,32 @@ function buildHomepage(): Markdown {
   return markdown;
 }
 
-let sidebar: Sidebar = [];
+let sidebar: Sidebar[] = [
+  {
+    'label': 'Blog',
+    'link': '/blog',
+    'icon': 'document',
+    'items': [],
+  },
+  {
+    'label': 'Overview',
+    'link': '1',
+    'icon': 'bars',
+    'items': [],
+  },
+  {
+    'label': 'AEPs',
+    'link': '/general',
+    'icon': 'bars',
+    'items': [],
+  },
+  {
+    'label': 'Tooling',
+    'link': '/tooling-and-ecosystem',
+    'icon': 'settings',
+    'items': [],
+  }
+];
 
 if (AEP_LOC != "") {
   // Build config.

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -307,12 +307,6 @@ function buildHomepage(): Markdown {
 
 let sidebar: Sidebar[] = [
   {
-    'label': 'Blog',
-    'link': '/blog',
-    'icon': 'document',
-    'items': [],
-  },
-  {
     'label': 'Overview',
     'link': '1',
     'icon': 'bars',
@@ -321,13 +315,19 @@ let sidebar: Sidebar[] = [
   {
     'label': 'AEPs',
     'link': '/general',
-    'icon': 'bars',
+    'icon': 'open-book',
     'items': [],
   },
   {
     'label': 'Tooling',
     'link': '/tooling-and-ecosystem',
-    'icon': 'settings',
+    'icon': 'puzzle',
+    'items': [],
+  },
+  {
+    'label': 'Blog',
+    'link': '/blog',
+    'icon': 'document',
     'items': [],
   }
 ];

--- a/scripts/src/sidebar.ts
+++ b/scripts/src/sidebar.ts
@@ -1,6 +1,6 @@
 import type { Sidebar, AEP, ConsolidatedLinterRule } from './types';
 
-function buildLinterSidebar(rules: ConsolidatedLinterRule[], sidebar: Sidebar): Sidebar {
+function buildLinterSidebar(rules: ConsolidatedLinterRule[], sidebar: Sidebar[]): Sidebar[] {
   let contents = [
     {
       'label': 'Protobuf Linter',
@@ -17,7 +17,7 @@ function buildLinterSidebar(rules: ConsolidatedLinterRule[], sidebar: Sidebar): 
   return addToSidebar(sidebar, "Tooling", contents);
 }
 
-function buildSidebar(aeps: AEP[], groups: any, sidebar: Sidebar): Sidebar {
+function buildSidebar(aeps: AEP[], groups: any, sidebar: Sidebar[]): Sidebar[] {
   let response = [];
   for (var group of groups.categories) {
     response.push({
@@ -29,7 +29,7 @@ function buildSidebar(aeps: AEP[], groups: any, sidebar: Sidebar): Sidebar {
   return addToSidebar(sidebar, "AEPs", response);
 }
 
-function addToSidebar(sidebar: Sidebar, label: string, items): Sidebar {
+function addToSidebar(sidebar: Sidebar[], label: string, items): Sidebar[] {
   const targetGroupIndex = sidebar.findIndex(group => group.label === label);
   if (targetGroupIndex != -1) {
     if (Array.isArray(sidebar[targetGroupIndex].items)) {

--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -33,9 +33,14 @@ const SideBarItem = z.object({
   items: z.array(z.union([z.string(), z.lazy(() => SideBarItem)]))
 });
 
-const Sidebar = z.array(SideBarItem);
+const SidebarItems = z.array(SideBarItem);
 
-type Sidebar = z.infer<typeof Sidebar>;
+interface Sidebar {
+  label: string
+  link: string
+  icon: string
+  items: z.infer<typeof SidebarItems>
+}
 
 interface AEP {
   title: string;

--- a/src/content/docs/tooling/index.md
+++ b/src/content/docs/tooling/index.md
@@ -1,5 +1,0 @@
----
-title: Tooling
----
-
-Look at all this tooling we have!


### PR DESCRIPTION
Our sidebar is a mess, which makes it hard to discover all of our content. This breaks up the sidebar into different sections: Overview, AEPs, Tooling, and Blog. Clicking on a topic shows you a set of headings under that topic. I've attached examples of what the sidebar looks like.

Clicking on the category defaults to AEP 1, The AEP List page, our tooling page, and our blog homepage accordingly.

<img width="297" alt="Screenshot 2025-04-20 at 9 46 55 PM" src="https://github.com/user-attachments/assets/42115fec-3aa2-4f80-9c20-ddb2155cd966" />
<img width="298" alt="Screenshot 2025-04-20 at 9 47 00 PM" src="https://github.com/user-attachments/assets/add6a070-e377-4970-8ba0-d4ed2ea1f24d" />
<img width="297" alt="Screenshot 2025-04-20 at 9 47 10 PM" src="https://github.com/user-attachments/assets/5981ad6d-a823-45af-baef-175224fdc785" />
<img width="290" alt="Screenshot 2025-04-20 at 9 47 15 PM" src="https://github.com/user-attachments/assets/62e00bae-3382-4161-9f61-2b4db1ab7175" />
