### PR TITLE
feat(links): auto add aep links, fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ src/content/docs/*.md
 src/content/*
 !src/content/docs/
 src/content/docs/*.mdx
-src/content/docs/*.md
+src/content/docs/**/*.md
 !src/content/docs/index.mdx
 
 public/json-schema/**/*.json
+public/llms.txt

--- a/scripts/src/markdown.ts
+++ b/scripts/src/markdown.ts
@@ -43,7 +43,7 @@ class Markdown {
         }
     }
 
-    public build() : string {
+    public build(): string {
         return `---
 ${dump(this.frontmatter)}
 ---
@@ -149,7 +149,7 @@ ${tabContents(match[3].trimStart())}
 </Aside>`
             this.contents = this.contents.replace(match[0], formatted_results);
         }
-        this.addComponent({'names': ['Aside'], 'path': '@astrojs/starlight/components'});
+        this.addComponent({ 'names': ['Aside'], 'path': '@astrojs/starlight/components' });
         return this;
     }
 
@@ -179,10 +179,20 @@ ${tabContents(match[3].trimStart())}
         return this;
     }
 
+    public substituteStandaloneAEPReferences() {
+        // Convert standalone AEP references (case-insensitive) to links
+        // This matches "aep-XXX" where X is a number, but avoids matching within existing links
+        this.contents = this.contents.replace(/ (aep-\d+)\b/gi, (match, aepRef) => {
+            const aepId = aepRef.replace(/^aep-/i, '');
+            return ` [${aepRef}](/${aepId})`;
+        });
+        return this;
+    }
+
 }
 
 function buildMarkdown(contents: string, folder: string): Markdown {
-    let result = new Markdown(contents);
+    let result = new Markdown(contents, {});
     return result.substituteSamples(folder)
         .substituteTabs()
         .substituteHTMLComments()
@@ -193,7 +203,8 @@ function buildMarkdown(contents: string, folder: string): Markdown {
         .substituteLinks()
         .substituteGraphviz()
         .substituteEBNF()
-        .substituteAEPLinks();
+        .substituteStandaloneAEPReferences()
+        .substituteAEPLinks()
 }
 
 function tabContents(contents: string): string {


### PR DESCRIPTION
aep-XXX should just automatically link to the appropriate
aep, saving significant boilerplate in the markdown.

also updating gitignore to skip more generated content.