### PR TITLE
Edition support!

### DIFF
--- a/aep-editions.json
+++ b/aep-editions.json
@@ -1,0 +1,8 @@
+{
+  "editions": [
+    {
+      "name": "latest",
+      "folder": "."
+    }
+  ]
+}

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ import tailwindcss from "@tailwindcss/vite";
 let sidebar = JSON.parse(fs.readFileSync("generated/sidebar.json"));
 let redirects = JSON.parse(fs.readFileSync("generated/redirects.json"));
 let config = JSON.parse(fs.readFileSync("generated/config.json"));
+let aepEditions = JSON.parse(fs.readFileSync("aep-editions.json"));
 
 // https://astro.build/config
 export default defineConfig({
@@ -31,7 +32,26 @@ export default defineConfig({
       ],
       plugins: [
         starlightBlog({ navigation: "none" }),
-        starlightSidebarTopics(sidebar, { exclude: ["/blog", "/blog/**/*"] }),
+        starlightSidebarTopics(sidebar, {
+          topics: {
+            aeps: aepEditions.editions
+              .filter((edition) => edition.folder !== ".")
+              .flatMap((edition) => [
+                `/${edition.folder}`,
+                `/${edition.folder}/**/*`,
+              ]),
+          },
+          exclude: [
+            "/blog",
+            "/blog/**/*",
+            ...aepEditions.editions
+              .filter((edition) => edition.folder !== ".")
+              .flatMap((edition) => [
+                `/${edition.folder}`,
+                `/${edition.folder}/**/*`,
+              ]),
+          ],
+        }),
       ],
       social: [
         { icon: "github", label: "GitHub", href: config.urls.repo },
@@ -47,9 +67,11 @@ export default defineConfig({
         },
       ],
       components: {
+        Banner: "./src/components/overrides/Banner.astro",
         Head: "./src/components/overrides/Head.astro",
         SkipLink: "./src/components/overrides/SkipLink.astro",
         TableOfContents: "./src/components/overrides/TableOfContents.astro",
+        ThemeSelect: "./src/components/overrides/ThemeSelect.astro",
       },
     }),
   ],

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -218,6 +218,8 @@ function buildAEP(files: string[], folder: string): AEP {
   const yaml = load(yaml_text);
 
   yaml.title = getTitle(md_text).replace("\n", "");
+  let slug = yaml.slug;
+  delete yaml.slug;
 
   let contents = buildMarkdown(md_text, folder);
 
@@ -228,7 +230,7 @@ function buildAEP(files: string[], folder: string): AEP {
   });
   contents.addComponent({
     names: ["Sample"],
-    path: "../../components/Sample.astro",
+    path: "/src/components/Sample.astro",
   });
 
   contents.frontmatter["prev"] = false;
@@ -240,17 +242,15 @@ function buildAEP(files: string[], folder: string): AEP {
   return {
     title: yaml.title,
     id: yaml.id,
+    slug: slug,
     frontmatter: yaml,
     category: yaml.placement.category,
     order: yaml.placement.order,
-    slug: yaml.slug,
     contents: contents,
   };
 }
 
 function writeMarkdown(aep: AEP) {
-  aep.contents.frontmatter.slug = aep.id.toString();
-
   const filePath = path.join("src/content/docs", `${aep.id}.mdx`);
   writeFile(filePath, aep.contents.build());
 }
@@ -478,24 +478,28 @@ let sidebar: Sidebar[] = [
     label: "Overview",
     link: "1",
     icon: "bars",
+    id: "overview",
     items: [],
   },
   {
     label: "AEPs",
     link: "/general",
     icon: "open-book",
+    id: "aeps",
     items: [],
   },
   {
     label: "Tooling",
     link: "/tooling-and-ecosystem",
     icon: "puzzle",
+    id: "tooling",
     items: [],
   },
   {
     label: "Blog",
     link: "/blog",
     icon: "document",
+    id: "blog",
     items: [],
   },
 ];

--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -43,17 +43,18 @@ interface Sidebar {
   label: string;
   link: string;
   icon: string;
+  id: string;
   items: z.infer<typeof SidebarItems>;
 }
 
 interface AEP {
   title: string;
   id: string;
+  slug: string;
   frontmatter: object;
   contents: Markdown;
   category: string;
   order: number;
-  slug: string;
 }
 
 interface LinterRule {

--- a/src/components/AepList/AepList.astro
+++ b/src/components/AepList/AepList.astro
@@ -6,6 +6,6 @@ const {category} = Astro.props;
 
 <div id="aep-list-container">
   {category.items.map((aep) => (
-    <AepListEntry title={aep.title} href={"/" + aep.slug} id={aep.id.toString()} state={aep.status} />
+    <AepListEntry title={aep.title} href={"/" + aep.id} id={aep.id.toString()} state={aep.status} />
   ))}
 </div>

--- a/src/components/EditionBanner.astro
+++ b/src/components/EditionBanner.astro
@@ -1,0 +1,37 @@
+---
+import editionsConfig from '../../aep-editions.json'
+import { getEditionFromPath, getVersionedPath } from '../utils/versions'
+
+const currentEdition = getEditionFromPath(editionsConfig, Astro.url.pathname)
+const latestEdition = editionsConfig.editions.find(e => e.name === 'latest')
+
+const isOlderVersion = currentEdition && currentEdition.name !== 'latest'
+const latestUrl = latestEdition ? getVersionedPath(editionsConfig, Astro.url.pathname, latestEdition) : null
+---
+
+{
+  isOlderVersion && (
+    <div>
+      This content is for {currentEdition.name}. Switch to the
+      {/* prettier-ignore */}
+      <a href={latestUrl}>latest version</a>
+      for up-to-date documentation.
+    </div>
+  )
+}
+
+<style>
+  div {
+    background-color: var(--sl-color-orange-low);
+    box-shadow: var(--sl-shadow-sm);
+    color: var(--sl-color-orange-high);
+    line-height: var(--sl-line-height-headings);
+    padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+    text-align: center;
+    text-wrap: balance;
+  }
+
+  div a {
+    color: var(--sl-color-orange-high);
+  }
+</style>

--- a/src/components/VersionSelect.astro
+++ b/src/components/VersionSelect.astro
@@ -1,0 +1,115 @@
+---
+import { Icon } from '@astrojs/starlight/components'
+import editionsConfig from '../../aep-editions.json'
+import { getEditionFromPath, getVersionedPath, isVersionedPage } from '../utils/versions'
+
+const currentEdition = getEditionFromPath(editionsConfig, Astro.url.pathname)
+const showVersionSelect = isVersionedPage(Astro.url.pathname)
+---
+
+{showVersionSelect && (
+  <aep-version-select>
+    <label>
+      <span class="sr-only">Select version</span>
+      <Icon name="seti:clock" class="icon label-icon" />
+      <select value={currentEdition?.name ?? 'latest'} autocomplete="off">
+        {editionsConfig.editions.map((edition) => (
+          <option
+            selected={edition.name === currentEdition?.name}
+            value={getVersionedPath(editionsConfig, Astro.url.pathname, edition)}
+          >
+            {edition.name}
+          </option>
+        ))}
+      </select>
+      <Icon name="down-caret" class="icon caret-icon" />
+    </label>
+  </aep-version-select>
+)}
+
+<style>
+  label {
+    --sl-versions-label-icon-size: 0.875rem;
+    --sl-versions-caret-icon-size: 1.25rem;
+
+    align-items: center;
+    color: var(--sl-color-gray-1);
+    display: flex;
+    gap: 0.25rem;
+    position: relative;
+  }
+
+  label:hover {
+    color: var(--sl-color-gray-2);
+  }
+
+  .icon {
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .label-icon {
+    font-size: var(--sl-versions-label-icon-size);
+    inset-inline-start: 0;
+  }
+
+  .caret-icon {
+    font-size: var(--sl-versions-caret-icon-size);
+    inset-inline-end: 0;
+  }
+
+  select {
+    appearance: none;
+    background-color: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    padding-block: 0.625rem;
+    padding-inline: calc(var(--sl-versions-label-icon-size) + 0.375rem)
+      calc(var(--sl-versions-caret-icon-size) + 0.25rem);
+    text-overflow: ellipsis;
+    width: 8em;
+  }
+
+  option {
+    background-color: var(--sl-color-bg-nav);
+    color: var(--sl-color-gray-1);
+  }
+
+  @media (min-width: 50rem) {
+    select {
+      font-size: var(--sl-text-sm);
+    }
+  }
+</style>
+
+<script>
+  customElements.define(
+    'aep-version-select',
+    class AepVersionSelect extends HTMLElement {
+      constructor() {
+        super()
+
+        const select = this.querySelector('select')
+        if (!select) return
+
+        select?.addEventListener('change', (event) => {
+          if (event.currentTarget instanceof HTMLSelectElement) {
+            globalThis.location.pathname = event.currentTarget.value
+          }
+        })
+
+        window.addEventListener('pageshow', (event) => {
+          if (!event.persisted) return
+          const markupSelectedIndex = select.querySelector<HTMLOptionElement>('option[selected]')?.index
+
+          if (markupSelectedIndex !== select.selectedIndex) {
+            select.selectedIndex = markupSelectedIndex ?? 0
+          }
+        })
+      }
+    },
+  )
+</script>

--- a/src/components/overrides/Banner.astro
+++ b/src/components/overrides/Banner.astro
@@ -1,0 +1,8 @@
+---
+import Default from '@astrojs/starlight/components/Banner.astro'
+
+import EditionBanner from '../EditionBanner.astro'
+---
+
+<EditionBanner />
+<Default><slot /></Default>

--- a/src/components/overrides/ThemeSelect.astro
+++ b/src/components/overrides/ThemeSelect.astro
@@ -1,0 +1,8 @@
+---
+import Default from '@astrojs/starlight/components/ThemeSelect.astro'
+
+import VersionSelect from '../VersionSelect.astro'
+---
+
+<VersionSelect />
+<Default><slot /></Default>

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,0 +1,61 @@
+interface Edition {
+  name: string;
+  folder: string;
+}
+
+interface EditionsConfig {
+  editions: Edition[];
+}
+
+export function getEditionFromPath(
+  editionsConfig: EditionsConfig,
+  currentPath: string,
+): Edition | undefined {
+  const pathSegments = currentPath.split("/").filter(Boolean);
+
+  for (const edition of editionsConfig.editions) {
+    if (
+      edition.folder === "." &&
+      !pathSegments.some((segment) =>
+        editionsConfig.editions.some((e) => e.folder === segment),
+      )
+    ) {
+      return edition;
+    }
+
+    if (edition.folder !== "." && pathSegments.includes(edition.folder)) {
+      return edition;
+    }
+  }
+
+  return editionsConfig.editions.find((e) => e.folder === ".");
+}
+
+export function getVersionedPath(
+  editionsConfig: EditionsConfig,
+  currentPath: string,
+  targetEdition: Edition,
+): string {
+  const pathSegments = currentPath.split("/").filter(Boolean);
+
+  const currentEdition = getEditionFromPath(editionsConfig, currentPath);
+
+  if (currentEdition?.folder && currentEdition.folder !== ".") {
+    const editionIndex = pathSegments.indexOf(currentEdition.folder);
+    if (editionIndex !== -1) {
+      pathSegments.splice(editionIndex, 1);
+    }
+  }
+
+  if (targetEdition.folder !== ".") {
+    pathSegments.unshift(targetEdition.folder);
+  }
+
+  return "/" + pathSegments.join("/");
+}
+
+export function isVersionedPage(path: string): boolean {
+  const segments = path.split("/").filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+  return /^\d+$/.test(lastSegment);
+}


### PR DESCRIPTION
Part of #82 

This is the main PR for Edition support on the site generator.

Right now, all of the AEPs are generated into `src/content/docs`. This assumes that the AEP copies for different editions will live in `src/content/docs/<aep-edition>/` and that the edition is listed in `aep-editions.json`. 

This PR accomplishes the following:
- Changes the canonical slug for each AEP to be the AEP number (minor technical detail, URLs still work as intended, but this allows us to offload a lot of the page routing to Starlight instead of trying to configure it manually)
- Adds a VersionSelector in the header that appears on AEP pages + allows you to change the edition
- Adds a Banner that displays text on older AEPs that redirects you to the latest.

The next step is to setup some scripting that clones the AEP repo at a given edition branch and writes their editioned AEPs to a given folder.

Note: This assumes that the list of AEPs in newer editions will match the list in older editions. That'll be a faulty assumption at some point, but that introduces a lot more work.