### PR TITLE
Add support for aep-openapi-linter documentation

### DIFF
--- a/scripts/src/sidebar.ts
+++ b/scripts/src/sidebar.ts
@@ -20,6 +20,46 @@ function buildLinterSidebar(
   return addToSidebar(sidebar, "Tooling", contents);
 }
 
+/**
+ * Builds sidebar entries for OpenAPI linter rules.
+ *
+ * @param rules Consolidated linter rules by AEP number
+ * @param sidebar Existing sidebar structure
+ * @returns Updated sidebar with OpenAPI linter entries
+ */
+function buildOpenAPILinterSidebar(
+  rules: ConsolidatedLinterRule[],
+  sidebar: Sidebar[],
+): Sidebar[] {
+  // Guard: Only add if we have rules to display
+  if (rules.length === 0) {
+    console.log("ℹ️  No OpenAPI linter rules to add to sidebar");
+    return sidebar;
+  }
+
+  // Create rule items sorted by AEP number
+  const ruleItems = rules
+    .sort((a, b) => a.aep.localeCompare(b.aep))
+    .map((rule) => `tooling/openapi-linter/rules/${rule.aep}`);
+
+  let contents = [
+    {
+      label: "OpenAPI Linter",
+      items: [
+        "tooling/openapi-linter",
+        {
+          label: "Rules",
+          collapsed: true, // Start collapsed for cleaner UI
+          items: ruleItems,
+        },
+      ],
+    },
+  ];
+
+  console.log(`✓ Added ${ruleItems.length} OpenAPI linter rules to sidebar`);
+  return addToSidebar(sidebar, "Tooling", contents);
+}
+
 function buildSidebar(aeps: AEP[], groups: any, sidebar: Sidebar[]): Sidebar[] {
   let response = [];
   for (var group of groups.categories) {
@@ -52,4 +92,9 @@ function addToSidebar(sidebar: Sidebar[], label: string, items): Sidebar[] {
   return sidebar;
 }
 
-export { buildSidebar, buildLinterSidebar, addToSidebar };
+export {
+  buildSidebar,
+  buildLinterSidebar,
+  buildOpenAPILinterSidebar,
+  addToSidebar,
+};


### PR DESCRIPTION
## Summary

  Integrates the `aep-openapi-linter` repository to display OpenAPI linter rules on aep.dev, following the same pattern as the existing `api-linter` (proto linter).

  ## Changes

  - Add `AEP_OPENAPI_LINTER_LOC` environment variable support
  - Implement `assembleOpenAPILinterRules()` with defensive checks
  - Add `buildOpenAPILinterSidebar()` for sidebar navigation
  - Process OpenAPI linter rules and generate pages under `tooling/openapi-linter/rules/`
  - Copy README.md as overview page

  ## Implementation Details

  The integration:
  - ✅ Gracefully skips if repository not configured (backwards compatible)
  - ✅ Reuses existing `buildLinterRule()` and `consolidateLinterRule()` functions
  - ✅ Follows the exact same pattern as proto linter for consistency
  - ✅ Includes defensive checks for missing directories
  - ✅ Provides clear console logging for debugging

  ## Testing

  Tested locally with and without the OpenAPI linter repository configured:
  - Without repo: Builds successfully, logs "OpenAPI linter repo not configured, skipping..."
  - With repo: Successfully processes 14 rule files and generates navigation

  ## Expected Output

  - **Overview**: `/tooling/openapi-linter`
  - **Rules**: `/tooling/openapi-linter/rules/0131`, `/tooling/openapi-linter/rules/0132`, etc.
  - **Navigation**: Appears under "Tooling" section alongside Protobuf Linter

  ## Related Issues

  Closes #86

  Part of aep-dev/aeps#361 (Phase 1 of 2-phase implementation)

  ## Checklist

  - [x] Code follows existing patterns
  - [x] Defensive programming implemented
  - [x] Prettier formatting applied
  - [x] Tested locally with graceful fallback
  - [x] No breaking changes to existing functionality

  The relationship:
  - This PR → Closes #86 ✅ (site-generator is now ready)
  - Next PR (in aeps repo) → Will close aeps#361 ✅ (adds the clone step)