### PR TITLE
Add aep-2026 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ The site generator requires external repositories to be cloned and referenced vi
 export AEP_LOCATION="../aeps"           # Main AEP documentation repo
 export AEP_LINTER_LOC="../api-linter"  # API linter rules repo
 export AEP_COMPONENTS_LOC="../aep-components"  # Components repo
+export AEP_EDITION_2026="../aeps-2026"  # (Optional) 2026 edition AEP repo
 npm run generate
 npm run dev
 ```
@@ -35,9 +36,10 @@ This is a two-stage site generator built on Astro and Starlight:
 ### Stage 1: Generator (`scripts/generate.ts`)
 
 - Reads documentation from multiple external repos (aeps, api-linter, aep-components)
+- Optionally processes AEP Edition 2026 content when `AEP_EDITION_2026` is set
 - Transforms AEP content (formatted as Markdown with Jinja2) and custom syntax into MDX
 - Generates sidebar configuration and navigation
-- Outputs processed files to `src/content/docs/` and `generated/`
+- Outputs processed files to `src/content/docs/` (and `src/content/docs/aep-2026/` for 2026 edition) and `generated/`
 
 ### Stage 2: Starlight Site
 
@@ -102,6 +104,7 @@ Run tests with `npm test`. Tests use a custom test runner and cover:
 ## Generated Files
 
 - `src/content/docs/` - Site content (MDX files)
+- `src/content/docs/aep-2026/` - AEP Edition 2026 content (MDX files, if `AEP_EDITION_2026` is set)
 - `generated/` - JSON configuration files (sidebar, redirects, etc.)
 - `public/llms.txt` - Consolidated AEP content for LLM training/reference
 - `public/json-schema/` - JSON schemas from components repo

--- a/aep-editions.json
+++ b/aep-editions.json
@@ -3,6 +3,10 @@
     {
       "name": "latest",
       "folder": "."
+    },
+    {
+      "name": "aep-2026",
+      "folder": "aep-2026"
     }
   ]
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,7 @@ export AEP_LOCATION="/tmp/aeps"
 export AEP_LINTER_LOC="/tmp/api-linter"
 export AEP_OPENAPI_LINTER_LOC="/tmp/aep-openapi-linter"
 export AEP_COMPONENTS_LOC="/tmp/aep-components"
+export AEP_EDITION_2026="/tmp/aeps-2026"
 
 if [ ! -d "${AEP_LOCATION}" ]; then
     git clone https://github.com/aep-dev/aeps.git "${AEP_LOCATION}"
@@ -20,6 +21,11 @@ fi
 
 if [ ! -d "${AEP_COMPONENTS}" ]; then
     git clone https://github.com/aep-dev/aep-components.git "${AEP_COMPONENTS_LOC}"
+fi
+
+if [ ! -d "${AEP_EDITION_2026}" ]; then
+    git clone https://github.com/aep-dev/aeps.git "${AEP_EDITION_2026}"
+    # TODO: Checkout the repo at a specific tag or branch for the 2026 edition
 fi
 
 npm install

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,8 +24,7 @@ if [ ! -d "${AEP_COMPONENTS}" ]; then
 fi
 
 if [ ! -d "${AEP_EDITION_2026}" ]; then
-    git clone https://github.com/aep-dev/aeps.git "${AEP_EDITION_2026}"
-    # TODO: Checkout the repo at a specific tag or branch for the 2026 edition
+    git clone --single-branch --branch aep-2026 https://github.com/aep-dev/aeps.git "${AEP_EDITION_2026}"
 fi
 
 npm install

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -502,7 +502,7 @@ if (AEP_EDITION_2026 != "") {
       const aep = buildAEP(files, folder);
 
       // Write to aep-2026 directory instead of root
-      aep.contents.frontmatter.slug = aep.id.toString();
+      aep.contents.frontmatter.slug = `aep-2026/${aep.id.toString()}`;
       const filePath = path.join("src/content/docs/aep-2026", `${aep.id}.mdx`);
       writeFile(filePath, aep.contents.build());
 


### PR DESCRIPTION
This is the necessary changes to the generator pipeline to get aep-2026 locked.

It's a draft (for now) until the release gets locked. This PR should act as the template for future editions.

What this does:
- The generator should take a repo containing aep-2026 and copy the files over to `src/content/docs/aep-2026` after processing
- `aep-editions.json` should include the new edition