### PR TITLE
Hide EditionBanner for latest edition

### DIFF
--- a/src/components/EditionBanner.astro
+++ b/src/components/EditionBanner.astro
@@ -3,9 +3,9 @@ import editionsConfig from '../../aep-editions.json'
 import { getEditionFromPath, getVersionedPath } from '../utils/versions'
 
 const currentEdition = getEditionFromPath(editionsConfig, Astro.url.pathname)
-const latestEdition = editionsConfig.editions.find(e => e.name === 'latest')
+const latestEdition = editionsConfig.editions.find(e => e.folder === '.')
 
-const isOlderVersion = currentEdition && currentEdition.name !== 'latest'
+const isOlderVersion = currentEdition && currentEdition.folder !== '.'
 const latestUrl = latestEdition ? getVersionedPath(editionsConfig, Astro.url.pathname, latestEdition) : null
 ---
 


### PR DESCRIPTION
The latest edition (identified by folder === '.') should not display
the EditionBanner. Updated logic to check folder property instead of
looking for a non-existent 'latest' edition name.

- Changed latestEdition lookup to find edition with folder === '.'
- Changed isOlderVersion check to compare folder property
- Banner now only shows for non-root editions (e.g., aep-2026)