### PR TITLE
Add edition-aware AEP links with AepLink component

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,9 @@ import starlightBlog from "starlight-blog";
 import starlightSidebarTopics from "starlight-sidebar-topics";
 import tailwindcss from "@tailwindcss/vite";
 
+// Helper function to check if an edition is the latest
+const isLatestEdition = (edition) => edition.folder === ".";
+
 let sidebar = JSON.parse(
   fs.readFileSync("generated/sidebar-from-site-structure.json"),
 );
@@ -34,7 +37,7 @@ export default defineConfig({
         starlightSidebarTopics(sidebar, {
           topics: {
             aeps: aepEditions.editions
-              .filter((edition) => edition.folder !== ".")
+              .filter((edition) => !isLatestEdition(edition))
               .flatMap((edition) => [
                 `/${edition.folder}`,
                 `/${edition.folder}/**/*`,
@@ -44,7 +47,7 @@ export default defineConfig({
             "/blog",
             "/blog/**/*",
             ...aepEditions.editions
-              .filter((edition) => edition.folder !== ".")
+              .filter((edition) => !isLatestEdition(edition))
               .flatMap((edition) => [
                 `/${edition.folder}`,
                 `/${edition.folder}/**/*`,

--- a/scripts/src/markdown.ts
+++ b/scripts/src/markdown.ts
@@ -232,23 +232,47 @@ ${tabContents(match[3].trimStart())}
 
   public substituteAEPLinks() {
     // The original site generator knew to magically replace [Create][aep-133] style links with their matching links.
-    // We need to first make these valid Markdown links that point to the correct link.
+    // We now use the AepLink component to make these edition-aware.
     this.contents = this.contents.replace(
       /\[([^\]]+)\]\[(aep-[^\]]+)\]/g,
       (match, first, second) => {
-        const alteredSecond = second.replace("aep-", "/"); // Remove 'aep-'
-        return `[${first}](${alteredSecond})`;
+        const aepNumber = second.replace("aep-", ""); // Remove 'aep-' prefix
+        return `<AepLink href="/${aepNumber}">${first}</AepLink>`;
       },
     );
+    this.addComponent({
+      names: ["AepLink"],
+      path: "../../components/AepLink.astro",
+    });
     return this;
   }
 
   public substituteStandaloneAEPReferences() {
-    // Convert standalone AEP references (case-insensitive) to links
+    // Convert standalone AEP references (case-insensitive) to edition-aware links
     // This matches "aep-XXX" where X is a number, but avoids matching within existing links
     this.contents = this.contents.replace(/ (aep-\d+)\b/gi, (match, aepRef) => {
       const aepId = aepRef.replace(/^aep-/i, "");
-      return ` [${aepRef}](/${aepId})`;
+      return ` <AepLink href="/${aepId}">${aepRef}</AepLink>`;
+    });
+    this.addComponent({
+      names: ["AepLink"],
+      path: "../../components/AepLink.astro",
+    });
+    return this;
+  }
+
+  public substitutePlainAEPLinks() {
+    // Convert plain markdown links to AEP numbers into AepLink components
+    // Matches [text](/123) or [text](123) where 123 is a number
+    this.contents = this.contents.replace(
+      /\[([^\]]+)\]\(\/(\d+)\)/g,
+      (match, text, aepNumber) => {
+        return `<AepLink href="/${aepNumber}">${text}</AepLink>`;
+      },
+    );
+    this.addComponent({
+      names: ["AepLink"],
+      path: "../../components/AepLink.astro",
     });
     return this;
   }
@@ -269,7 +293,8 @@ function buildMarkdown(contents: string, folder: string): Markdown {
     .substituteGraphviz()
     .substituteEBNF()
     .substituteStandaloneAEPReferences()
-    .substituteAEPLinks();
+    .substituteAEPLinks()
+    .substitutePlainAEPLinks();
 }
 
 function tabContents(contents: string): string {

--- a/scripts/src/markdown.ts
+++ b/scripts/src/markdown.ts
@@ -242,7 +242,7 @@ ${tabContents(match[3].trimStart())}
     );
     this.addComponent({
       names: ["AepLink"],
-      path: "../../components/AepLink.astro",
+      path: "@components/AepLink.astro",
     });
     return this;
   }
@@ -256,7 +256,7 @@ ${tabContents(match[3].trimStart())}
     });
     this.addComponent({
       names: ["AepLink"],
-      path: "../../components/AepLink.astro",
+      path: "@components/AepLink.astro",
     });
     return this;
   }
@@ -272,7 +272,7 @@ ${tabContents(match[3].trimStart())}
     );
     this.addComponent({
       names: ["AepLink"],
-      path: "../../components/AepLink.astro",
+      path: "@components/AepLink.astro",
     });
     return this;
   }

--- a/src/components/AepLink.astro
+++ b/src/components/AepLink.astro
@@ -1,0 +1,29 @@
+---
+import editionsConfig from '../../aep-editions.json'
+import { getEditionFromPath } from '../utils/versions'
+
+interface Props {
+  href: string
+  class?: string
+}
+
+const { href, class: className } = Astro.props
+
+// Normalize the href to just the number
+const aepNumber = href.replace(/^\//, '')
+
+// Get the current edition based on the page's pathname
+const currentEdition = getEditionFromPath(editionsConfig, Astro.url.pathname)
+
+// Construct the edition-aware link
+let editionAwareHref: string
+if (currentEdition?.folder && currentEdition.folder !== '.') {
+  // If we're in a versioned edition, prefix the link with the edition folder
+  editionAwareHref = `/${currentEdition.folder}/${aepNumber}`
+} else {
+  // Default edition (root)
+  editionAwareHref = `/${aepNumber}`
+}
+---
+
+<a href={editionAwareHref} class={className}><slot /></a>

--- a/src/components/AepLink.astro
+++ b/src/components/AepLink.astro
@@ -1,6 +1,6 @@
 ---
 import editionsConfig from '../../aep-editions.json'
-import { getEditionFromPath } from '../utils/versions'
+import { getEditionFromPath, isLatestEdition } from '../utils/versions'
 
 interface Props {
   href: string
@@ -17,9 +17,9 @@ const currentEdition = getEditionFromPath(editionsConfig, Astro.url.pathname)
 
 // Construct the edition-aware link
 let editionAwareHref: string
-if (currentEdition?.folder && currentEdition.folder !== '.') {
+if (!isLatestEdition(currentEdition)) {
   // If we're in a versioned edition, prefix the link with the edition folder
-  editionAwareHref = `/${currentEdition.folder}/${aepNumber}`
+  editionAwareHref = `/${currentEdition!.folder}/${aepNumber}`
 } else {
   // Default edition (root)
   editionAwareHref = `/${aepNumber}`

--- a/src/components/EditionBanner.astro
+++ b/src/components/EditionBanner.astro
@@ -1,11 +1,11 @@
 ---
 import editionsConfig from '../../aep-editions.json'
-import { getEditionFromPath, getVersionedPath } from '../utils/versions'
+import { getEditionFromPath, getVersionedPath, isLatestEdition } from '../utils/versions'
 
 const currentEdition = getEditionFromPath(editionsConfig, Astro.url.pathname)
-const latestEdition = editionsConfig.editions.find(e => e.folder === '.')
+const latestEdition = editionsConfig.editions.find(e => isLatestEdition(e))
 
-const isOlderVersion = currentEdition && currentEdition.folder !== '.'
+const isOlderVersion = !isLatestEdition(currentEdition)
 const latestUrl = latestEdition ? getVersionedPath(editionsConfig, Astro.url.pathname, latestEdition) : null
 ---
 

--- a/src/utils/site-structure.ts
+++ b/src/utils/site-structure.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { AEP } from "../../scripts/src/types";
+import { isLatestEdition } from "./versions";
 
 /**
  * Represents a single page item in the navigation
@@ -221,9 +222,9 @@ function getLatestEditionName(siteStructure: SiteStructure): string | null {
     return null;
   }
 
-  // Check for edition with folder = "."
-  const currentFolderEdition = editionNames.find(
-    (name) => siteStructure.aeps.editions[name].folder === ".",
+  // Check for edition with folder = "." (latest edition)
+  const currentFolderEdition = editionNames.find((name) =>
+    isLatestEdition(siteStructure.aeps.editions[name]),
   );
   if (currentFolderEdition) {
     return currentFolderEdition;

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -7,6 +7,10 @@ interface EditionsConfig {
   editions: Edition[];
 }
 
+export function isLatestEdition(edition: Edition | undefined): boolean {
+  return edition?.folder === ".";
+}
+
 export function getEditionFromPath(
   editionsConfig: EditionsConfig,
   currentPath: string,
@@ -15,7 +19,7 @@ export function getEditionFromPath(
 
   for (const edition of editionsConfig.editions) {
     if (
-      edition.folder === "." &&
+      isLatestEdition(edition) &&
       !pathSegments.some((segment) =>
         editionsConfig.editions.some((e) => e.folder === segment),
       )
@@ -23,12 +27,12 @@ export function getEditionFromPath(
       return edition;
     }
 
-    if (edition.folder !== "." && pathSegments.includes(edition.folder)) {
+    if (!isLatestEdition(edition) && pathSegments.includes(edition.folder)) {
       return edition;
     }
   }
 
-  return editionsConfig.editions.find((e) => e.folder === ".");
+  return editionsConfig.editions.find((e) => isLatestEdition(e));
 }
 
 export function getVersionedPath(
@@ -40,14 +44,14 @@ export function getVersionedPath(
 
   const currentEdition = getEditionFromPath(editionsConfig, currentPath);
 
-  if (currentEdition?.folder && currentEdition.folder !== ".") {
+  if (currentEdition && !isLatestEdition(currentEdition)) {
     const editionIndex = pathSegments.indexOf(currentEdition.folder);
     if (editionIndex !== -1) {
       pathSegments.splice(editionIndex, 1);
     }
   }
 
-  if (targetEdition.folder !== ".") {
+  if (!isLatestEdition(targetEdition)) {
     pathSegments.unshift(targetEdition.folder);
   }
 

--- a/test/aepLinks.test.ts
+++ b/test/aepLinks.test.ts
@@ -1,0 +1,158 @@
+import { Markdown } from "../scripts/src/markdown";
+import { describe, it, expect } from "@jest/globals";
+
+describe("AEP Link Transformations", () => {
+  it("should convert [text][aep-123] to AepLink component", () => {
+    const content = `
+# Test Document
+
+See the [Create][aep-133] method for more details.
+Also check out [List][aep-132] and [Update][aep-134].
+`;
+
+    const markdown = new Markdown(content, {});
+    markdown.substituteAEPLinks();
+
+    const result = markdown.contents;
+
+    expect(result).toContain('<AepLink href="/133">Create</AepLink>');
+    expect(result).toContain('<AepLink href="/132">List</AepLink>');
+    expect(result).toContain('<AepLink href="/134">Update</AepLink>');
+
+    // Verify component was added to imports
+    expect(
+      markdown.components.some(
+        (c) =>
+          c.names.includes("AepLink") &&
+          c.path === "@components/AepLink.astro",
+      ),
+    ).toBe(true);
+  });
+
+  it("should convert standalone AEP references", () => {
+    const content = `
+# Test Document
+
+This is related to aep-123 and aep-456.
+Another reference to AEP-789 (case insensitive).
+`;
+
+    const markdown = new Markdown(content, {});
+    markdown.substituteStandaloneAEPReferences();
+
+    const result = markdown.contents;
+
+    expect(result).toContain('<AepLink href="/123">aep-123</AepLink>');
+    expect(result).toContain('<AepLink href="/456">aep-456</AepLink>');
+    expect(result).toContain('<AepLink href="/789">AEP-789</AepLink>');
+
+    // Verify component was added to imports
+    expect(
+      markdown.components.some(
+        (c) =>
+          c.names.includes("AepLink") &&
+          c.path === "@components/AepLink.astro",
+      ),
+    ).toBe(true);
+  });
+
+  it("should convert plain markdown links to AepLink", () => {
+    const content = `
+# Test Document
+
+See [Create](/133) for more details.
+Also check [List](/132) and [Update](/134).
+`;
+
+    const markdown = new Markdown(content, {});
+    markdown.substitutePlainAEPLinks();
+
+    const result = markdown.contents;
+
+    expect(result).toContain('<AepLink href="/133">Create</AepLink>');
+    expect(result).toContain('<AepLink href="/132">List</AepLink>');
+    expect(result).toContain('<AepLink href="/134">Update</AepLink>');
+
+    // Verify component was added to imports
+    expect(
+      markdown.components.some(
+        (c) =>
+          c.names.includes("AepLink") &&
+          c.path === "@components/AepLink.astro",
+      ),
+    ).toBe(true);
+  });
+
+  it("should not convert links to non-AEP pages", () => {
+    const content = `
+# Test Document
+
+See [documentation](/docs/getting-started) for more.
+Also visit [our blog](/blog/2024/hello-world).
+`;
+
+    const markdown = new Markdown(content, {});
+    markdown.substitutePlainAEPLinks();
+
+    const result = markdown.contents;
+
+    // These should remain as plain markdown
+    expect(result).not.toContain("AepLink");
+    expect(result).toContain("[documentation](/docs/getting-started)");
+  });
+
+  it("should only import AepLink component once", () => {
+    const content = `
+# Test Document
+
+See [Create][aep-133] and aep-134 and [Delete](/135).
+`;
+
+    const markdown = new Markdown(content, {});
+    markdown
+      .substituteAEPLinks()
+      .substituteStandaloneAEPReferences()
+      .substitutePlainAEPLinks();
+
+    // Count how many times AepLink appears in components
+    const aepLinkComponents = markdown.components.filter(
+      (c) =>
+        c.names.includes("AepLink") && c.path === "@components/AepLink.astro",
+    );
+
+    expect(aepLinkComponents.length).toBe(1);
+
+    // Verify all three AepLinks are in the content
+    expect(markdown.contents).toContain(
+      '<AepLink href="/133">Create</AepLink>',
+    );
+    expect(markdown.contents).toContain(
+      '<AepLink href="/134">aep-134</AepLink>',
+    );
+    expect(markdown.contents).toContain(
+      '<AepLink href="/135">Delete</AepLink>',
+    );
+  });
+
+  it("should handle edge cases with AEP numbers", () => {
+    const content = `
+# Test Document
+
+See [Short](/1) and [Long](/1234).
+Also aep-9999 and [Reference][aep-007].
+`;
+
+    const markdown = new Markdown(content, {});
+    markdown
+      .substituteAEPLinks()
+      .substituteStandaloneAEPReferences()
+      .substitutePlainAEPLinks();
+
+    const result = markdown.contents;
+
+    expect(result).toContain('<AepLink href="/1">Short</AepLink>');
+    expect(result).toContain('<AepLink href="/1234">Long</AepLink>');
+    expect(result).toContain('<AepLink href="/9999">aep-9999</AepLink>');
+    expect(result).toContain('<AepLink href="/007">Reference</AepLink>');
+  });
+});

--- a/test/aepLinks.test.ts
+++ b/test/aepLinks.test.ts
@@ -23,8 +23,7 @@ Also check out [List][aep-132] and [Update][aep-134].
     expect(
       markdown.components.some(
         (c) =>
-          c.names.includes("AepLink") &&
-          c.path === "@components/AepLink.astro",
+          c.names.includes("AepLink") && c.path === "@components/AepLink.astro",
       ),
     ).toBe(true);
   });
@@ -50,8 +49,7 @@ Another reference to AEP-789 (case insensitive).
     expect(
       markdown.components.some(
         (c) =>
-          c.names.includes("AepLink") &&
-          c.path === "@components/AepLink.astro",
+          c.names.includes("AepLink") && c.path === "@components/AepLink.astro",
       ),
     ).toBe(true);
   });
@@ -77,8 +75,7 @@ Also check [List](/132) and [Update](/134).
     expect(
       markdown.components.some(
         (c) =>
-          c.names.includes("AepLink") &&
-          c.path === "@components/AepLink.astro",
+          c.names.includes("AepLink") && c.path === "@components/AepLink.astro",
       ),
     ).toBe(true);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"]
+    }
+  }
 }


### PR DESCRIPTION
This change makes AEP links dynamically adjust based on the current edition:

- Created AepLink component that determines edition from current page URL
- Links within aep-2026 edition pages now point to /aep-2026/{number}
- Links in default edition pages point to /{number}
- Updated markdown transformations to use AepLink for all AEP references:
  * [text][aep-123] format
  * Standalone "AEP-123" text references
  * Plain markdown links like [text](/123)
- Added comprehensive test suite for AEP link transformations

This ensures users stay within the same edition when navigating between AEPs.