### PR TITLE
Fix version selector width to display full version names

### DIFF
--- a/src/components/VersionSelect.astro
+++ b/src/components/VersionSelect.astro
@@ -70,7 +70,7 @@ const showVersionSelect = isVersionedPage(Astro.url.pathname)
     padding-inline: calc(var(--sl-versions-label-icon-size) + 0.375rem)
       calc(var(--sl-versions-caret-icon-size) + 0.25rem);
     text-overflow: ellipsis;
-    width: 8em;
+    width: 13em;
   }
 
   option {


### PR DESCRIPTION
Increased the width from 8em to 13em to accommodate the longest version
text "aep-2028-preview" (16 characters). The previous width was too narrow
and caused text truncation.