### PR TITLE
Close protobuf and OpenAPI linter sections by default

### DIFF
--- a/src/utils/sidebar-from-site-structure.ts
+++ b/src/utils/sidebar-from-site-structure.ts
@@ -111,6 +111,7 @@ function assembleToolingItems(siteStructure: SiteStructure): any[] {
   ) {
     items.push({
       label: "Protobuf Linter",
+      collapsed: true,
       items: [
         "tooling/linter",
         {
@@ -131,6 +132,7 @@ function assembleToolingItems(siteStructure: SiteStructure): any[] {
   ) {
     items.push({
       label: "OpenAPI Linter",
+      collapsed: true,
       items: [
         "tooling/openapi-linter",
         {


### PR DESCRIPTION
Add collapsed: true to both Protobuf Linter and OpenAPI Linter sections
in the sidebar configuration to make them closed by default instead of open.